### PR TITLE
Restore deprecated templates for BC in 1.1

### DIFF
--- a/UPGRADE-1.1.md
+++ b/UPGRADE-1.1.md
@@ -1,0 +1,19 @@
+# UPGRADE FROM 1.0 TO 1.1
+
+## Granular Twig Hooks
+
+We've introduced granular Twig hooks to provide better customization capabilities. The following templates have been deprecated and will be removed in 2.0:
+
+- `@SyliusWishlistPlugin/common/remove_from_wishlist.html.twig`
+- `@SyliusWishlistPlugin/wishlist_details/global_actions.html.twig`
+- `@SyliusWishlistPlugin/wishlist_details/item.html.twig`
+
+### Migration to Granular Hooks
+
+If you have overridden any of the deprecated templates, consider migrating to the new granular Twig hooks system to prepare for the 2.0 upgrade.
+
+The new granular hooks are defined in:
+- `config/twig_hooks/wishlist.yaml` - for wishlist details page hooks
+- `config/twig_hooks/wishlist_group.yaml` - for wishlist group-related hooks
+- `config/twig_hooks/common/` - for common hooks used across multiple pages
+- `config/twig_hooks/product/` - for product-related hooks

--- a/templates/common/remove_from_wishlist.html.twig
+++ b/templates/common/remove_from_wishlist.html.twig
@@ -1,0 +1,10 @@
+{% deprecated "This template is deprecated since 1.1 and will be removed in 2.0. Use granular Twig hooks instead: @see config/twig_hooks/wishlist.yaml" %}
+<a
+    href="{{ path('sylius_wishlist_plugin_shop_locale_wishlist_remove_product_variant', { wishlistId: wishlist.id, variantId: variant.id }) }}"
+    class="btn btn-sm btn-outline-secondary"
+    data-product-name="{{ product.name }}"
+    data-tooltip="{{ 'sylius_wishlist_plugin.ui.remove_from_wishlist'|trans }}"
+    {{ sylius_test_html_attribute('wishlist-remove-item') }}
+>
+    {{ ux_icon('flowbite:x-outline', {'class': 'icon icon-sm'}) }}
+</a>

--- a/templates/wishlist_details/global_actions.html.twig
+++ b/templates/wishlist_details/global_actions.html.twig
@@ -1,0 +1,19 @@
+{% deprecated "This template is deprecated since 1.1 and will be removed in 2.0. Use granular Twig hooks instead: @see config/twig_hooks/wishlist.yaml" %}
+<a href="{{ path('sylius_wishlist_plugin_shop_locale_wishlist_import_from_csv') }}">
+    <button type="button" class="btn btn-icon btn-outline-secondary w-100" {{ sylius_test_html_attribute('wishlist-import-from-csv') }}>
+        {{ ux_icon('mdi:import', {'class': 'icon icon-sm'}) }}
+        {{ 'sylius_wishlist_plugin.ui.import_from_csv'|trans }}
+    </button>
+</a>
+
+<button
+    id="{{ form.addAll.vars.id }}"
+    name="{{ form.addAll.vars.full_name }}"
+    class="btn btn-icon btn-primary"
+    data-bb-toggle="wishlist-add-all"
+    {{ sylius_test_html_attribute('wishlist-add-all-to-cart') }}
+    formaction="{{ path('sylius_wishlist_plugin_shop_locale_wishlist_add_products', { wishlistId: wishlist.id }) }}"
+>
+    {{ ux_icon('mdi:heart', {'class': 'icon icon-sm'}) }}
+    {{ form.addAll.vars.label|trans }}
+</button>

--- a/templates/wishlist_details/item.html.twig
+++ b/templates/wishlist_details/item.html.twig
@@ -1,0 +1,50 @@
+{% deprecated "This template is deprecated since 1.1 and will be removed in 2.0. Use granular Twig hooks instead: @see config/twig_hooks/wishlist.yaml" %}
+{% form_theme form '@SyliusShop/form/theme.html.twig' %}
+
+{% set variant = itemForm.vars.value.wishlistProduct.variant %}
+{% set product = variant.product %}
+{% set productUrl = path('sylius_shop_product_show', { slug: product.slug, _locale: product.translation.locale }) %}
+{% set itemId = "wishlist_item_#{ variant.id }_#{ product.id }" %}
+
+<div id="{{ itemId }}" class="bb-wishlist-item">
+    <div class="bb-wishlist-item-select" data-bb-checkboxes="checkboxes-update-when-main">
+        {{ form_widget(itemForm.selected, { id: product.name, label: false }) }}
+    </div>
+    <div class="bb-wishlist-item-image">
+        {{ component('sylius_shop:main_image', { product: product }) }}
+    </div>
+    <div class="bb-wishlist-item-name">
+        <a href="{{ productUrl }}" {{ sylius_test_html_attribute('wishlist-item-name') }}>
+            {{ product.name }}
+        </a>
+    </div>
+    <div class="bb-wishlist-item-variant">
+        {% if itemForm.cartItem.cartItem.variant is defined %}
+            <div class="bb-wishlist-variant">
+                {% for child in itemForm.cartItem.cartItem.variant.children %}
+                    <div class="bb-wishlist-variant-option">
+                        {{ form_label(child, null, { label_attr: { class: 'bb-wishlist-variant-label'} } ) }}
+                        {{ form_widget(child, { attr: { class: 'bb-wishlist-variant-select', 'data-name': child.vars.name } } ) }}
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
+    <div class="bb-wishlist-item-price">
+        {% if not product.variants.empty() %}
+            {% include '@SyliusWishlistPlugin/wishlist_details/variant_price.html.twig' %}
+        {% endif %}
+    </div>
+    <div class="bb-wishlist-item-quantity" {{ sylius_test_html_attribute('wishlist-item-quantity') }}>
+        {{ form_widget(itemForm.cartItem.cartItem.quantity, {
+            'attr': {
+                'min': 0,
+                'data-product-name': product.name,
+                'value': itemForm.cartItem.cartItem.quantity.vars.value is same as("0") ? 1 : itemForm.cartItem.cartItem.quantity.vars.value
+            }
+        }) }}
+    </div>
+    <div class="bb-wishlist-item-actions">
+        {% include '@SyliusWishlistPlugin/common/remove_from_wishlist.html.twig' %}
+    </div>
+</div>


### PR DESCRIPTION
## Summary

- Restored 3 templates that were removed in 2.0 to maintain backward compatibility in the 1.1 minor release
- Added UPGRADE-1.1.md file

## Details

Templates restored with deprecation notices:
- `templates/common/remove_from_wishlist.html.twig`
- `templates/wishlist_details/global_actions.html.twig`
- `templates/wishlist_details/item.html.twig`
