### PR TITLE
FEATURE: Expose action to add a specific productVariant to the wishlist

### DIFF
--- a/config/routes/shop.yaml
+++ b/config/routes/shop.yaml
@@ -45,6 +45,11 @@ wishlist_import_from_csv:
     defaults:
         _controller: sylius_wishlist_plugin.controller.action.import_from_csv
 
+wishlist_add_product_variant:
+    path: /wishlist/add/variant/{variantId}
+    defaults:
+        _controller: sylius_wishlist_plugin.controller.action.add_product_variant_to_wishlist
+
 wishlist_remove_product_variant:
     path: /wishlist/{wishlistId}/remove/variant/{variantId}
     defaults:

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -79,8 +79,8 @@
             <argument type="service" id="sylius_wishlist_plugin.factory.wishlist_product"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="translator"/>
-            <argument type="service" id="router"/>
-            <argument type="service" id="sylius_wishlist_plugin.repository.wishlist"/>
+            <argument type="service" id="sylius_wishlist_plugin.resolver.wishlists_resolver"/>
+            <argument type="service" id="sylius_wishlist_plugin.manager.wishlist"/>
             <tag name="controller.service_arguments"/>
         </service>
 

--- a/src/Controller/Action/AddProductVariantToWishlistAction.php
+++ b/src/Controller/Action/AddProductVariantToWishlistAction.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\WishlistPlugin\Controller\Action;
 
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 use Sylius\WishlistPlugin\Entity\WishlistInterface;
 use Sylius\WishlistPlugin\Entity\WishlistProductInterface;
+use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
 use Sylius\WishlistPlugin\Factory\WishlistProductFactoryInterface;
 use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
+use Sylius\WishlistPlugin\Resolver\WishlistsResolverInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -33,68 +36,41 @@ final readonly class AddProductVariantToWishlistAction
 {
     public function __construct(
         private ProductVariantRepositoryInterface $productVariantRepository,
-        private WishlistProductFactoryInterface $wishlistProductFactory,
-        private RequestStack $requestStack,
-        private TranslatorInterface $translator,
-        private UrlGeneratorInterface $urlGenerator,
-        private WishlistRepositoryInterface $wishlistRepository,
+        private WishlistProductFactoryInterface   $wishlistProductFactory,
+        private RequestStack                      $requestStack,
+        private TranslatorInterface               $translator,
+        private WishlistsResolverInterface        $wishlistsResolver,
+        private ObjectManager $wishlistManager,
     ) {
     }
 
-    public function __invoke(int $wishlistId, Request $request): Response
+    public function __invoke(Request $request): Response
     {
-        /** @var ?WishlistInterface $wishlist */
-        $wishlist = $this->wishlistRepository->find($wishlistId);
+        $variant = $this->productVariantRepository->find($request->get('variantId'));
+
+        if (null === $variant) {
+            throw new NotFoundHttpException(sprintf('Product variantwith code %s not found.', $request->get('variantId')));
+        }
+        $wishlists = $this->wishlistsResolver->resolveAndCreate();
+        $wishlist = array_shift($wishlists);
 
         if (null === $wishlist) {
-            throw new ResourceNotFoundException();
+            throw new WishlistNotFoundException(
+                $this->translator->trans('sylius_wishlist_plugin.ui.wishlist_not_found'),
+            );
         }
-
-        foreach ((array) $request->get('variantId') as $variantId) {
-            /** @var ProductVariantInterface|null $variant */
-            $variant = $this->productVariantRepository->find($variantId);
-
-            if (null === $variant) {
-                throw new NotFoundHttpException();
-            }
-
             /** @var WishlistProductInterface $wishlistProduct */
-            $wishlistProduct = $this->wishlistProductFactory->createForWishlistAndVariant($wishlist, $variant);
+        $wishlistProduct = $this->wishlistProductFactory->createForWishlistAndVariant($wishlist, $variant);
+        $wishlist->addWishlistProduct($wishlistProduct);
 
-            $this->addProductToWishlist($wishlist, $variant, $wishlistProduct);
-        }
-
-        return new RedirectResponse(
-            $this->urlGenerator->generate('sylius_wishlist_plugin_shop_locale_wishlist_show_chosen_wishlist', [
-                'wishlistId' => $wishlistId,
-            ]),
-        );
-    }
-
-    private function addProductToWishlist(
-        WishlistInterface $wishlist,
-        ProductVariantInterface $variant,
-        WishlistProductInterface $wishlistProduct,
-    ): void {
+        $this->wishlistManager->flush();
         /** @var Session $session */
         $session = $this->requestStack->getSession();
+        $session->getFlashBag()->add('success', $this->translator->trans('sylius_wishlist_plugin.ui.added_wishlist_item'));
 
-        $flashBag = $session->getFlashBag();
+        $referer = $request->headers->get('referer');
+        $refererPathInfo = Request::create((string) $referer)->getPathInfo();
 
-        if ($wishlist->hasProductVariant($variant)) {
-            $flashBag->add(
-                'error',
-                $this->translator->trans(
-                    'sylius_wishlist_plugin.ui.wishlist_has_product_variant',
-                    ['%productName%' => $wishlistProduct->getProduct()->getName()],
-                ),
-            );
-
-            return;
-        }
-
-        $wishlist->addWishlistProduct($wishlistProduct);
-        $this->wishlistRepository->add($wishlist);
-        $flashBag->add('success', $this->translator->trans('sylius_wishlist_plugin.ui.added_wishlist_item'));
+        return new RedirectResponse($refererPathInfo);
     }
 }


### PR DESCRIPTION
The 'AddProductVariantToWishlistAction' is now routed to '/wishlist/add/variant/{variantId}', which aligns with the existing product variant naming scheme.

I also refactored the action to align it with the 'AddProductToWishlistAction', as this seemed to be the more evolved approach.

Resolves: #38 