### PR TITLE
FEATURE: Expose action to add a specific productVariant to the wishlist

### DIFF
--- a/config/routes/shop.yaml
+++ b/config/routes/shop.yaml
@@ -45,6 +45,11 @@ wishlist_import_from_csv:
     defaults:
         _controller: sylius_wishlist_plugin.controller.action.import_from_csv
 
+wishlist_add_product_variant:
+    path: /wishlist/add/variant/{variantId}
+    defaults:
+        _controller: sylius_wishlist_plugin.controller.action.add_product_variant_to_wishlist
+
 wishlist_remove_product_variant:
     path: /wishlist/{wishlistId}/remove/variant/{variantId}
     defaults:

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -79,6 +79,8 @@
             <argument type="service" id="sylius_wishlist_plugin.factory.wishlist_product"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="translator"/>
+            <argument type="service" id="sylius_wishlist_plugin.resolver.wishlists_resolver"/>
+            <argument type="service" id="sylius_wishlist_plugin.manager.wishlist"/>
             <argument type="service" id="router"/>
             <argument type="service" id="sylius_wishlist_plugin.repository.wishlist"/>
             <tag name="controller.service_arguments"/>

--- a/src/CommandHandler/Wishlist/ImportWishlistFromCsvHandler.php
+++ b/src/CommandHandler/Wishlist/ImportWishlistFromCsvHandler.php
@@ -47,6 +47,7 @@ final readonly class ImportWishlistFromCsvHandler
         $fileInfo = $importWishlistFromCsv->getFileInfo();
         $request = $importWishlistFromCsv->getRequest();
         $wishlistId = $importWishlistFromCsv->getWishlistId();
+        $request->attributes->set('wishlistId', $wishlistId);
 
         $this->getDataFromFile($fileInfo, $request);
 

--- a/src/CommandHandler/Wishlist/ImportWishlistFromCsvHandler.php
+++ b/src/CommandHandler/Wishlist/ImportWishlistFromCsvHandler.php
@@ -50,8 +50,9 @@ final readonly class ImportWishlistFromCsvHandler
         $request->attributes->set('wishlistId', $wishlistId);
 
         $this->getDataFromFile($fileInfo, $request);
+        $request->attributes->set('wishlistId', $wishlistId);
 
-        return $this->addProductVariantToWishlistAction->__invoke($wishlistId, $request);
+        return $this->addProductVariantToWishlistAction->__invoke($request);
     }
 
     private function getDataFromFile(\SplFileInfo $fileInfo, Request $request): void

--- a/src/Controller/Action/AddProductVariantToWishlistAction.php
+++ b/src/Controller/Action/AddProductVariantToWishlistAction.php
@@ -28,8 +28,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Exception\ResourceNotFoundException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -37,13 +35,13 @@ final readonly class AddProductVariantToWishlistAction
 {
     public function __construct(
         private ProductVariantRepositoryInterface $productVariantRepository,
-        private WishlistProductFactoryInterface   $wishlistProductFactory,
-        private RequestStack                      $requestStack,
-        private TranslatorInterface               $translator,
-        private WishlistsResolverInterface        $wishlistsResolver,
-        private ObjectManager                     $wishlistManager,
-        private RouterInterface                   $router,
-        private WishlistRepositoryInterface       $wishlistRepository,
+        private WishlistProductFactoryInterface $wishlistProductFactory,
+        private RequestStack $requestStack,
+        private TranslatorInterface $translator,
+        private WishlistsResolverInterface $wishlistsResolver,
+        private ObjectManager $wishlistManager,
+        private RouterInterface $router,
+        private WishlistRepositoryInterface $wishlistRepository,
     ) {
     }
 
@@ -51,7 +49,7 @@ final readonly class AddProductVariantToWishlistAction
     {
         $wishlist = $this->resolveWishlist($request);
 
-        foreach ((array)$request->get('variantId') as $variantId) {
+        foreach ((array) $request->get('variantId') as $variantId) {
             /** @var ProductVariantInterface|null $variant */
             $variant = $this->productVariantRepository->find($variantId);
 
@@ -75,7 +73,6 @@ final readonly class AddProductVariantToWishlistAction
             ]),
         );
     }
-
 
     private function resolveWishlist(Request $request): WishlistInterface
     {

--- a/src/Controller/Action/AddProductVariantToWishlistAction.php
+++ b/src/Controller/Action/AddProductVariantToWishlistAction.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\WishlistPlugin\Controller\Action;
 
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 use Sylius\WishlistPlugin\Entity\WishlistInterface;
 use Sylius\WishlistPlugin\Entity\WishlistProductInterface;
+use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
 use Sylius\WishlistPlugin\Factory\WishlistProductFactoryInterface;
 use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
+use Sylius\WishlistPlugin\Resolver\WishlistsResolverInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -27,30 +30,28 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class AddProductVariantToWishlistAction
 {
     public function __construct(
         private ProductVariantRepositoryInterface $productVariantRepository,
-        private WishlistProductFactoryInterface $wishlistProductFactory,
-        private RequestStack $requestStack,
-        private TranslatorInterface $translator,
-        private UrlGeneratorInterface $urlGenerator,
-        private WishlistRepositoryInterface $wishlistRepository,
+        private WishlistProductFactoryInterface   $wishlistProductFactory,
+        private RequestStack                      $requestStack,
+        private TranslatorInterface               $translator,
+        private WishlistsResolverInterface        $wishlistsResolver,
+        private ObjectManager                     $wishlistManager,
+        private RouterInterface                   $router,
+        private WishlistRepositoryInterface       $wishlistRepository,
     ) {
     }
 
-    public function __invoke(int $wishlistId, Request $request): Response
+    public function __invoke(Request $request): Response
     {
-        /** @var ?WishlistInterface $wishlist */
-        $wishlist = $this->wishlistRepository->find($wishlistId);
+        $wishlist = $this->resolveWishlist($request);
 
-        if (null === $wishlist) {
-            throw new ResourceNotFoundException();
-        }
-
-        foreach ((array) $request->get('variantId') as $variantId) {
+        foreach ((array)$request->get('variantId') as $variantId) {
             /** @var ProductVariantInterface|null $variant */
             $variant = $this->productVariantRepository->find($variantId);
 
@@ -60,41 +61,42 @@ final readonly class AddProductVariantToWishlistAction
 
             /** @var WishlistProductInterface $wishlistProduct */
             $wishlistProduct = $this->wishlistProductFactory->createForWishlistAndVariant($wishlist, $variant);
-
-            $this->addProductToWishlist($wishlist, $variant, $wishlistProduct);
+            $wishlist->addWishlistProduct($wishlistProduct);
         }
 
+        $this->wishlistManager->flush();
+        /** @var Session $session */
+        $session = $this->requestStack->getSession();
+        $session->getFlashBag()->add('success', $this->translator->trans('sylius_wishlist_plugin.ui.added_wishlist_item'));
+
         return new RedirectResponse(
-            $this->urlGenerator->generate('sylius_wishlist_plugin_shop_locale_wishlist_show_chosen_wishlist', [
-                'wishlistId' => $wishlistId,
+            $this->router->generate('sylius_wishlist_plugin_shop_locale_wishlist_show_chosen_wishlist', [
+                'wishlistId' => $wishlist->getId(),
             ]),
         );
     }
 
-    private function addProductToWishlist(
-        WishlistInterface $wishlist,
-        ProductVariantInterface $variant,
-        WishlistProductInterface $wishlistProduct,
-    ): void {
-        /** @var Session $session */
-        $session = $this->requestStack->getSession();
 
-        $flashBag = $session->getFlashBag();
+    private function resolveWishlist(Request $request): WishlistInterface
+    {
+        $wishlistId = $request->get('wishListId');
+        if (null !== $wishlistId) {
+            $wishlist = $this->wishlistRepository->find($wishlistId);
 
-        if ($wishlist->hasProductVariant($variant)) {
-            $flashBag->add(
-                'error',
-                $this->translator->trans(
-                    'sylius_wishlist_plugin.ui.wishlist_has_product_variant',
-                    ['%productName%' => $wishlistProduct->getProduct()->getName()],
-                ),
-            );
-
-            return;
+            if ($wishlist instanceof WishlistInterface) {
+                return $wishlist;
+            }
         }
 
-        $wishlist->addWishlistProduct($wishlistProduct);
-        $this->wishlistRepository->add($wishlist);
-        $flashBag->add('success', $this->translator->trans('sylius_wishlist_plugin.ui.added_wishlist_item'));
+        $wishlists = $this->wishlistsResolver->resolveAndCreate();
+        $wishlist = array_shift($wishlists);
+
+        if ($wishlist instanceof WishlistInterface) {
+            return $wishlist;
+        }
+
+        throw new WishlistNotFoundException(
+            $this->translator->trans('sylius_wishlist_plugin.ui.wishlist_not_found'),
+        );
     }
 }

--- a/tests/Unit/Controller/Action/AddProductVariantToWishlistActionTest.php
+++ b/tests/Unit/Controller/Action/AddProductVariantToWishlistActionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\WishlistPlugin\Unit\Controller\Action;
 
+use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -20,16 +21,18 @@ use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 use Sylius\WishlistPlugin\Controller\Action\AddProductVariantToWishlistAction;
 use Sylius\WishlistPlugin\Entity\WishlistInterface;
 use Sylius\WishlistPlugin\Entity\WishlistProductInterface;
+use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
 use Sylius\WishlistPlugin\Factory\WishlistProductFactoryInterface;
 use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
+use Sylius\WishlistPlugin\Resolver\WishlistsResolverInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class AddProductVariantToWishlistActionTest extends TestCase
@@ -42,7 +45,11 @@ final class AddProductVariantToWishlistActionTest extends TestCase
 
     private MockObject&TranslatorInterface $translator;
 
-    private MockObject&UrlGeneratorInterface $urlGenerator;
+    private MockObject&UrlGeneratorInterface $router;
+
+    private MockObject&ObjectManager $wishlistManager;
+
+    private MockObject&WishlistsResolverInterface $wishlistsResolver;
 
     private MockObject&WishlistRepositoryInterface $wishlistRepository;
 
@@ -58,16 +65,20 @@ final class AddProductVariantToWishlistActionTest extends TestCase
         $this->wishlistProductFactory = $this->createMock(WishlistProductFactoryInterface::class);
         $this->requestStack = $this->createMock(RequestStack::class);
         $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $this->router = $this->createMock(RouterInterface::class);
         $this->wishlistRepository = $this->createMock(WishlistRepositoryInterface::class);
+        $this->wishlistsResolver = $this->createMock(WishlistsResolverInterface::class);
         $this->request = $this->createMock(Request::class);
         $this->wishlist = $this->createMock(WishlistInterface::class);
+        $this->wishlistManager = $this->createMock(ObjectManager::class);
         $this->action = new AddProductVariantToWishlistAction(
             $this->productVariantRepository,
             $this->wishlistProductFactory,
             $this->requestStack,
             $this->translator,
-            $this->urlGenerator,
+            $this->wishlistsResolver,
+            $this->wishlistManager,
+            $this->router,
             $this->wishlistRepository,
         );
     }
@@ -79,10 +90,10 @@ final class AddProductVariantToWishlistActionTest extends TestCase
 
     public function testShouldThrow404WhenWishlistIsNotFound(): void
     {
-        $this->expectException(ResourceNotFoundException::class);
+        $this->expectException(WishlistNotFoundException::class);
         $this->wishlistRepository->expects($this->once())->method('find')->with(1)->willReturn(null);
-
-        ($this->action)(1, $this->request);
+        $this->request->expects($this->once())->method('get')->with('wishListId')->willReturn(1);
+        ($this->action)($this->request);
     }
 
     public function testShouldThrow404WhenProductIsNotFound(): void
@@ -90,9 +101,10 @@ final class AddProductVariantToWishlistActionTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
         $this->wishlistRepository->expects($this->once())->method('find')->with(1)->willReturn($this->wishlist);
         $this->request->expects($this->once())->method('get')->with('variantId')->willReturn(1);
+        $this->request->expects($this->once())->method('get')->with('wishListId')->willReturn(1);
         $this->productVariantRepository->expects($this->once())->method('find')->with(1)->willReturn(null);
 
-        ($this->action)(1, $this->request);
+        ($this->action)($this->request);
     }
 
     public function testShouldHandleTheRequestAndPersistNewWishlistForLoggedShopUser(): void
@@ -108,7 +120,7 @@ final class AddProductVariantToWishlistActionTest extends TestCase
         $this->wishlist->expects($this->once())->method('hasProductVariant')->with($productVariant)->willReturn(false);
         $this->wishlistProductFactory->expects($this->once())->method('createForWishlistAndVariant')->with($this->wishlist, $productVariant)->willReturn($wishlistProduct);
         $this->translator->expects($this->once())->method('trans')->with('sylius_wishlist_plugin.ui.added_wishlist_item')->willReturn('Product has been added to your wishlist.');
-        $this->urlGenerator->expects($this->once())->method('generate')->with('sylius_wishlist_plugin_shop_locale_wishlist_show_chosen_wishlist', ['wishlistId' => 1])->willReturn('/wishlist/1');
+        $this->router->expects($this->once())->method('generate')->with('sylius_wishlist_plugin_shop_locale_wishlist_show_chosen_wishlist', ['wishlistId' => 1])->willReturn('/wishlist/1');
         $this->wishlist->expects($this->once())->method('addWishlistProduct')->with($wishlistProduct);
         $this->wishlistRepository->expects($this->once())->method('add')->with($this->wishlist);
         $this->requestStack->expects($this->once())->method('getSession')->willReturn($session);
@@ -117,7 +129,7 @@ final class AddProductVariantToWishlistActionTest extends TestCase
 
         $this->assertInstanceOf(
             RedirectResponse::class,
-            ($this->action)(1, $this->request),
+            ($this->action)($this->request),
         );
     }
 }


### PR DESCRIPTION
The 'AddProductVariantToWishlistAction' is now routed to '/wishlist/add/variant/{variantId}', which aligns with the existing product variant naming scheme.

I also refactored the action to align it with the 'AddProductToWishlistAction', as this seemed to be the more evolved approach.

Resolves: https://github.com/Sylius/WishlistPlugin/issues/38