### PR TITLE
Add PostgreSQL migrations

### DIFF
--- a/src/Migrations/Version20201029161559.php
+++ b/src/Migrations/Version20201029161559.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\WishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20201029161559 extends AbstractPostgreSQLMigration
+{
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('bitbag_wishlist')) {
+            return;
+        }
+
+        $this->addSql('CREATE TABLE bitbag_wishlist (id SERIAL NOT NULL, shop_user_id INT DEFAULT NULL, token VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_578D4E775F37A13B ON bitbag_wishlist (token)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_578D4E77A45D93BF ON bitbag_wishlist (shop_user_id)');
+        $this->addSql('CREATE TABLE bitbag_wishlist_product (id SERIAL NOT NULL, wishlist_id INT NOT NULL, product_id INT DEFAULT NULL, variant_id INT DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_3DBE67A0FB8E54CD ON bitbag_wishlist_product (wishlist_id)');
+        $this->addSql('CREATE INDEX IDX_3DBE67A04584665A ON bitbag_wishlist_product (product_id)');
+        $this->addSql('CREATE INDEX IDX_3DBE67A03B69A9AF ON bitbag_wishlist_product (variant_id)');
+        $this->addSql('ALTER TABLE bitbag_wishlist ADD CONSTRAINT FK_578D4E77A45D93BF FOREIGN KEY (shop_user_id) REFERENCES sylius_shop_user (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE bitbag_wishlist_product ADD CONSTRAINT FK_3DBE67A0FB8E54CD FOREIGN KEY (wishlist_id) REFERENCES bitbag_wishlist (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE bitbag_wishlist_product ADD CONSTRAINT FK_3DBE67A04584665A FOREIGN KEY (product_id) REFERENCES sylius_product (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE bitbag_wishlist_product ADD CONSTRAINT FK_3DBE67A03B69A9AF FOREIGN KEY (variant_id) REFERENCES sylius_product_variant (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bitbag_wishlist_product DROP CONSTRAINT FK_3DBE67A0FB8E54CD');
+        $this->addSql('DROP TABLE bitbag_wishlist');
+        $this->addSql('DROP TABLE bitbag_wishlist_product');
+    }
+}

--- a/src/Migrations/Version20210428130553.php
+++ b/src/Migrations/Version20210428130553.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\WishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20210428130553 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add missing constraint to bitbag_wishlist_product (PostgreSQL)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bitbag_wishlist_product DROP CONSTRAINT FK_3DBE67A0FB8E54CD');
+        $this->addSql('ALTER TABLE bitbag_wishlist_product ADD CONSTRAINT FK_3DBE67A0FB8E54CD FOREIGN KEY (wishlist_id) REFERENCES bitbag_wishlist (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bitbag_wishlist_product DROP CONSTRAINT FK_3DBE67A0FB8E54CD');
+        $this->addSql('ALTER TABLE bitbag_wishlist_product ADD CONSTRAINT FK_3DBE67A0FB8E54CD FOREIGN KEY (wishlist_id) REFERENCES bitbag_wishlist (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}

--- a/src/Migrations/Version20230522123448.php
+++ b/src/Migrations/Version20230522123448.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\WishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20230522123448 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add missing fields and indexes to wishlists (PostgreSQL)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->getTable('bitbag_wishlist')->hasColumn('channel_id')) {
+            return;
+        }
+
+        $this->addSql('ALTER TABLE bitbag_wishlist ADD channel_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE bitbag_wishlist ADD name VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE bitbag_wishlist ADD CONSTRAINT FK_578D4E7772F5A1AA FOREIGN KEY (channel_id) REFERENCES sylius_channel (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_578D4E7772F5A1AA ON bitbag_wishlist (channel_id)');
+
+        $this->addSql('DROP INDEX UNIQ_578D4E77A45D93BF');
+        $this->addSql('CREATE INDEX IDX_578D4E77A45D93BF ON bitbag_wishlist (shop_user_id)');
+        $this->addSql('DROP INDEX UNIQ_578D4E775F37A13B');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bitbag_wishlist DROP CONSTRAINT FK_578D4E7772F5A1AA');
+        $this->addSql('DROP INDEX IDX_578D4E7772F5A1AA');
+        $this->addSql('ALTER TABLE bitbag_wishlist DROP channel_id');
+        $this->addSql('ALTER TABLE bitbag_wishlist DROP name');
+
+        $this->addSql('DROP INDEX IDX_578D4E77A45D93BF');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_578D4E77A45D93BF ON bitbag_wishlist (shop_user_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_578D4E775F37A13B ON bitbag_wishlist (token)');
+    }
+}

--- a/src/Migrations/Version20231015123539.php
+++ b/src/Migrations/Version20231015123539.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\WishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20231015123539 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adding timestampable columns to track creating and updating a wishlist (PostgreSQL)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->getTable('bitbag_wishlist')->hasColumn('created_at')) {
+            return;
+        }
+
+        $this->addSql('ALTER TABLE bitbag_wishlist ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE bitbag_wishlist ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('UPDATE bitbag_wishlist SET created_at = NOW()');
+        $this->addSql('ALTER TABLE bitbag_wishlist ALTER COLUMN created_at SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bitbag_wishlist DROP created_at');
+        $this->addSql('ALTER TABLE bitbag_wishlist DROP updated_at');
+    }
+}

--- a/src/Migrations/Version20231030194731.php
+++ b/src/Migrations/Version20231030194731.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\WishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20231030194731 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds token_idx and channel_shop_user_token_idx indexes to database (PostgreSQL)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->getTable('bitbag_wishlist')->hasIndex('token_idx')) {
+            return;
+        }
+
+        $this->addSql('CREATE INDEX token_idx ON bitbag_wishlist (token)');
+        $this->addSql('CREATE INDEX channel_shop_user_token_idx ON bitbag_wishlist (channel_id, shop_user_id, token)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX token_idx');
+        $this->addSql('DROP INDEX channel_shop_user_token_idx');
+    }
+}

--- a/src/Migrations/Version20250427090023.php
+++ b/src/Migrations/Version20250427090023.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\WishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20250427090023 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'This migration renames the wishlist tables from BitBag to Sylius (PostgreSQL).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bitbag_wishlist RENAME TO sylius_wishlist');
+        $this->addSql('ALTER TABLE bitbag_wishlist_product RENAME TO sylius_wishlist_product');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_wishlist RENAME TO bitbag_wishlist');
+        $this->addSql('ALTER TABLE sylius_wishlist_product RENAME TO bitbag_wishlist_product');
+    }
+}

--- a/src/Migrations/Version20250429195906.php
+++ b/src/Migrations/Version20250429195906.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\WishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20250429195906 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'This migration renames indexes in sylius_wishlist and sylius_wishlist_product tables (PostgreSQL).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER INDEX idx_578d4e77a45d93bf RENAME TO IDX_635A71DEA45D93BF');
+        $this->addSql('ALTER INDEX idx_578d4e7772f5a1aa RENAME TO IDX_635A71DE72F5A1AA');
+        $this->addSql('ALTER INDEX idx_3dbe67a0fb8e54cd RENAME TO IDX_8D0D7C6DFB8E54CD');
+        $this->addSql('ALTER INDEX idx_3dbe67a04584665a RENAME TO IDX_8D0D7C6D4584665A');
+        $this->addSql('ALTER INDEX idx_3dbe67a03b69a9af RENAME TO IDX_8D0D7C6D3B69A9AF');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER INDEX idx_635a71dea45d93bf RENAME TO IDX_578D4E77A45D93BF');
+        $this->addSql('ALTER INDEX idx_635a71de72f5a1aa RENAME TO IDX_578D4E7772F5A1AA');
+        $this->addSql('ALTER INDEX idx_8d0d7c6d4584665a RENAME TO IDX_3DBE67A04584665A');
+        $this->addSql('ALTER INDEX idx_8d0d7c6d3b69a9af RENAME TO IDX_3DBE67A03B69A9AF');
+        $this->addSql('ALTER INDEX idx_8d0d7c6dfb8e54cd RENAME TO IDX_3DBE67A0FB8E54CD');
+    }
+}

--- a/src/Migrations/Version20250827052727.php
+++ b/src/Migrations/Version20250827052727.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\WishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20250827052727 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add quantity column to sylius_wishlist_product table (PostgreSQL)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_wishlist_product ADD quantity INT NOT NULL DEFAULT 1');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_wishlist_product DROP quantity');
+    }
+}


### PR DESCRIPTION
Adds PostgreSQL migration counterparts for all 8 existing MySQL-only migrations. Each PostgreSQL migration extends `AbstractPostgreSQLMigration` (which skips execution on MySQL) and uses PostgreSQL-appropriate SQL syntax: `SERIAL` for auto-increment, `TIMESTAMP(0) WITHOUT TIME ZONE` for datetime, `ALTER INDEX ... RENAME TO` instead of `ALTER TABLE ... RENAME INDEX`, `DROP CONSTRAINT` instead of `DROP FOREIGN KEY`, and separate `CREATE INDEX` statements instead of inline index definitions.