### PR TITLE
Refactor remove commands to accept wishlist object instead of token  

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,26 @@
+# UPGRADE FROM 1.x TO 2.0
+
+## Remove commands no longer accept wishlist token
+
+`RemoveProductFromWishlist` and `RemoveProductVariantFromWishlist` commands no longer accept a wishlist token string in their constructor. Instead, they follow the same pattern as `AddProductToWishlist` — you pass the product/variant ID in the constructor and set the wishlist object via `setWishlist()`.
+
+**Reason:** The wishlist token is not unique per wishlist — all wishlists of an anonymous user share the same cookie token. This made it impossible to target a specific wishlist in multi-wishlist scenarios.
+
+**Before (1.x):**
+```php
+$command = new RemoveProductFromWishlist($productId, $wishlistToken);
+$this->messageBus->dispatch($command);
+```
+
+**After (2.0):**
+```php
+$command = new RemoveProductFromWishlist($productId);
+$command->setWishlist($wishlist);
+$this->messageBus->dispatch($command);
+```
+
+The same applies to `RemoveProductVariantFromWishlist`.
+
+### Authorization moved to controllers
+
+The `RemoveProductFromWishlistHandler` and `RemoveProductVariantFromWishlistHandler` no longer perform authorization checks. Authorization (`WishlistVoter::DELETE`) is now the responsibility of the calling controller. If you dispatch these commands from custom code, ensure you verify permissions before dispatching.

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -7,11 +7,15 @@
     <services>
         <service id="sylius_wishlist_plugin.controller.action.api_platform.remove_product_from_wishlist_action" class="Sylius\WishlistPlugin\Controller\Action\ApiPlatform\RemoveProductFromWishlistAction">
             <argument type="service" id="api_platform.message_bus"/>
+            <argument type="service" id="sylius_wishlist_plugin.repository.wishlist"/>
+            <argument type="service" id="security.helper"/>
             <tag name="controller.service_arguments"/>
         </service>
 
         <service id="sylius_wishlist_plugin.controller.action.api_platform.remove_product_variant_from_wishlist_action" class="Sylius\WishlistPlugin\Controller\Action\ApiPlatform\RemoveProductVariantFromWishlistAction">
             <argument type="service" id="api_platform.message_bus"/>
+            <argument type="service" id="sylius_wishlist_plugin.repository.wishlist"/>
+            <argument type="service" id="security.helper"/>
             <tag name="controller.service_arguments"/>
         </service>
 

--- a/config/services/message_handler.xml
+++ b/config/services/message_handler.xml
@@ -40,19 +40,13 @@
 
         <service id="sylius_wishlist_plugin.command_handler.wishlist.remove_product_from_wishlist_handler" class="Sylius\WishlistPlugin\CommandHandler\Wishlist\RemoveProductFromWishlistHandler">
             <argument type="service" id="sylius.repository.product"/>
-            <argument type="service" id="sylius_wishlist_plugin.repository.wishlist"/>
-            <argument type="service" id="sylius_wishlist_plugin.repository.wishlist_product"/>
             <argument type="service" id="sylius_wishlist_plugin.manager.wishlist"/>
-            <argument type="service" id="security.authorization_checker"/>
             <tag name="messenger.message_handler"/>
         </service>
 
         <service id="sylius_wishlist_plugin.command_handler.wishlist.remove_product_variant_from_wishlist_handler" class="Sylius\WishlistPlugin\CommandHandler\Wishlist\RemoveProductVariantFromWishlistHandler">
-            <argument type="service" id="sylius_wishlist_plugin.repository.wishlist"/>
             <argument type="service" id="sylius.repository.product_variant"/>
-            <argument type="service" id="sylius_wishlist_plugin.repository.wishlist_product"/>
             <argument type="service" id="sylius_wishlist_plugin.manager.wishlist"/>
-            <argument type="service" id="security.authorization_checker"/>
             <tag name="messenger.message_handler"/>
         </service>
 

--- a/src/Command/Wishlist/RemoveProductFromWishlist.php
+++ b/src/Command/Wishlist/RemoveProductFromWishlist.php
@@ -13,21 +13,23 @@ declare(strict_types=1);
 
 namespace Sylius\WishlistPlugin\Command\Wishlist;
 
-final readonly class RemoveProductFromWishlist implements WishlistSyncCommandInterface
+use Sylius\WishlistPlugin\Entity\WishlistInterface;
+
+final class RemoveProductFromWishlist implements WishlistTokenValueAwareInterface
 {
-    public function __construct(
-        private int $productId,
-        private string $wishlistToken,
-    ) {
+    private WishlistInterface $wishlist;
+
+    public function __construct(public readonly int $productId)
+    {
     }
 
-    public function getProductIdValue(): int
+    public function getWishlist(): WishlistInterface
     {
-        return $this->productId;
+        return $this->wishlist;
     }
 
-    public function getWishlistTokenValue(): string
+    public function setWishlist(WishlistInterface $wishlist): void
     {
-        return $this->wishlistToken;
+        $this->wishlist = $wishlist;
     }
 }

--- a/src/Command/Wishlist/RemoveProductVariantFromWishlist.php
+++ b/src/Command/Wishlist/RemoveProductVariantFromWishlist.php
@@ -13,21 +13,23 @@ declare(strict_types=1);
 
 namespace Sylius\WishlistPlugin\Command\Wishlist;
 
-final readonly class RemoveProductVariantFromWishlist implements WishlistSyncCommandInterface
+use Sylius\WishlistPlugin\Entity\WishlistInterface;
+
+final class RemoveProductVariantFromWishlist implements WishlistTokenValueAwareInterface
 {
-    public function __construct(
-        private int $productVariantId,
-        private string $wishlistToken,
-    ) {
+    private WishlistInterface $wishlist;
+
+    public function __construct(public readonly int $productVariantId)
+    {
     }
 
-    public function getProductVariantIdValue(): int
+    public function getWishlist(): WishlistInterface
     {
-        return $this->productVariantId;
+        return $this->wishlist;
     }
 
-    public function getWishlistTokenValue(): string
+    public function setWishlist(WishlistInterface $wishlist): void
     {
-        return $this->wishlistToken;
+        $this->wishlist = $wishlist;
     }
 }

--- a/src/CommandHandler/Wishlist/RemoveProductFromWishlistHandler.php
+++ b/src/CommandHandler/Wishlist/RemoveProductFromWishlistHandler.php
@@ -16,67 +16,41 @@ namespace Sylius\WishlistPlugin\CommandHandler\Wishlist;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Sylius\Resource\ResourceActions;
 use Sylius\WishlistPlugin\Command\Wishlist\RemoveProductFromWishlist;
 use Sylius\WishlistPlugin\Entity\WishlistInterface;
 use Sylius\WishlistPlugin\Entity\WishlistProductInterface;
 use Sylius\WishlistPlugin\Exception\ProductNotFoundException;
-use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
-use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 #[AsMessageHandler]
 final readonly class RemoveProductFromWishlistHandler
 {
     public function __construct(
         private ProductRepositoryInterface $productRepository,
-        private WishlistRepositoryInterface $wishlistRepository,
-        private RepositoryInterface $wishlistProductRepository,
         private ObjectManager $wishlistManager,
-        private AuthorizationCheckerInterface $authorizationChecker,
     ) {
     }
 
     public function __invoke(RemoveProductFromWishlist $removeProductFromWishlist): WishlistInterface
     {
-        $productId = $removeProductFromWishlist->getProductIdValue();
-        $token = $removeProductFromWishlist->getWishlistTokenValue();
-
         /** @var ?ProductInterface $product */
-        $product = $this->productRepository->find($productId);
+        $product = $this->productRepository->find($removeProductFromWishlist->productId);
 
         if (null === $product) {
             throw new ProductNotFoundException(
-                sprintf('The Product %s does not exist', $productId),
+                sprintf('The Product %s does not exist', $removeProductFromWishlist->productId),
             );
         }
 
-        /** @var ?WishlistInterface $wishlist */
-        $wishlist = $this->wishlistRepository->findByToken($token);
+        $wishlist = $removeProductFromWishlist->getWishlist();
 
-        if (null === $wishlist) {
-            throw new WishlistNotFoundException(
-                sprintf('The Wishlist %s does not exist', $token),
-            );
+        /** @var WishlistProductInterface $wishlistProduct */
+        foreach ($wishlist->getWishlistProducts() as $wishlistProduct) {
+            if ($wishlistProduct->getProduct()?->getId() === $product->getId()) {
+                $wishlist->removeProduct($wishlistProduct);
+            }
         }
 
-        if (!$this->authorizationChecker->isGranted(ResourceActions::DELETE, $wishlist)) {
-            throw new AccessDeniedException('You are not allowed to delete from this wishlist.');
-        }
-
-        /** @var ?WishlistProductInterface $wishlistProduct */
-        $wishlistProduct = $this->wishlistProductRepository->findOneBy(['product' => $product, 'wishlist' => $wishlist]);
-
-        if (null === $wishlistProduct) {
-            throw new ProductNotFoundException(
-                sprintf('The Product %s was not found in Wishlist %s', $productId, $token),
-            );
-        }
-
-        $wishlist->removeProduct($wishlistProduct);
         $this->wishlistManager->flush();
 
         return $wishlist;

--- a/src/CommandHandler/Wishlist/RemoveProductVariantFromWishlistHandler.php
+++ b/src/CommandHandler/Wishlist/RemoveProductVariantFromWishlistHandler.php
@@ -16,67 +16,41 @@ namespace Sylius\WishlistPlugin\CommandHandler\Wishlist;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Sylius\Resource\ResourceActions;
 use Sylius\WishlistPlugin\Command\Wishlist\RemoveProductVariantFromWishlist;
 use Sylius\WishlistPlugin\Entity\WishlistInterface;
 use Sylius\WishlistPlugin\Entity\WishlistProductInterface;
 use Sylius\WishlistPlugin\Exception\ProductVariantNotFoundException;
-use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
-use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 #[AsMessageHandler]
 final readonly class RemoveProductVariantFromWishlistHandler
 {
     public function __construct(
-        private WishlistRepositoryInterface $wishlistRepository,
         private ProductVariantRepositoryInterface $productVariantRepository,
-        private RepositoryInterface $wishlistProductRepository,
         private ObjectManager $wishlistManager,
-        private AuthorizationCheckerInterface $authorizationChecker,
     ) {
     }
 
     public function __invoke(RemoveProductVariantFromWishlist $removeProductVariantFromWishlist): WishlistInterface
     {
-        $variantId = $removeProductVariantFromWishlist->getProductVariantIdValue();
-        $token = $removeProductVariantFromWishlist->getWishlistTokenValue();
-
         /** @var ?ProductVariantInterface $variant */
-        $variant = $this->productVariantRepository->find($variantId);
+        $variant = $this->productVariantRepository->find($removeProductVariantFromWishlist->productVariantId);
 
         if (null === $variant) {
             throw new ProductVariantNotFoundException(
-                sprintf('The Product Variant %s does not exist', $variantId),
+                sprintf('The Product Variant %s does not exist', $removeProductVariantFromWishlist->productVariantId),
             );
         }
 
-        /** @var ?WishlistInterface $wishlist */
-        $wishlist = $this->wishlistRepository->findByToken($token);
+        $wishlist = $removeProductVariantFromWishlist->getWishlist();
 
-        if (null === $wishlist) {
-            throw new WishlistNotFoundException(
-                sprintf('The Wishlist %s does not exist', $token),
-            );
+        /** @var WishlistProductInterface $wishlistProduct */
+        foreach ($wishlist->getWishlistProducts() as $wishlistProduct) {
+            if ($wishlistProduct->getVariant()?->getId() === $variant->getId()) {
+                $wishlist->removeProduct($wishlistProduct);
+            }
         }
 
-        if (!$this->authorizationChecker->isGranted(ResourceActions::DELETE, $wishlist)) {
-            throw new AccessDeniedException('You are not allowed to delete from this wishlist.');
-        }
-
-        /** @var ?WishlistProductInterface $wishlistProduct */
-        $wishlistProduct = $this->wishlistProductRepository->findOneBy(['variant' => $variant, 'wishlist' => $wishlist]);
-
-        if (null === $wishlistProduct) {
-            throw new ProductVariantNotFoundException(
-                sprintf('The Product Variant %s was not found in Wishlist %s', $variantId, $token),
-            );
-        }
-
-        $wishlist->removeProduct($wishlistProduct);
         $this->wishlistManager->flush();
 
         return $wishlist;

--- a/src/Controller/Action/ApiPlatform/RemoveProductFromWishlistAction.php
+++ b/src/Controller/Action/ApiPlatform/RemoveProductFromWishlistAction.php
@@ -14,15 +14,23 @@ declare(strict_types=1);
 namespace Sylius\WishlistPlugin\Controller\Action\ApiPlatform;
 
 use Sylius\WishlistPlugin\Command\Wishlist\RemoveProductFromWishlist;
+use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
+use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
+use Sylius\WishlistPlugin\Voter\WishlistVoter;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final readonly class RemoveProductFromWishlistAction
 {
-    public function __construct(private MessageBusInterface $messageBus)
-    {
+    public function __construct(
+        private MessageBusInterface $messageBus,
+        private WishlistRepositoryInterface $wishlistRepository,
+        private Security $security,
+    ) {
     }
 
     public function __invoke(Request $request): JsonResponse
@@ -30,8 +38,21 @@ final readonly class RemoveProductFromWishlistAction
         $wishlistToken = (string) $request->attributes->get('token');
         $productId = (int) $request->attributes->get('productId');
 
-        $removeProductFromWishlist = new RemoveProductFromWishlist($productId, $wishlistToken);
-        $this->messageBus->dispatch($removeProductFromWishlist);
+        $wishlist = $this->wishlistRepository->findByToken($wishlistToken);
+
+        if (null === $wishlist) {
+            throw new WishlistNotFoundException(
+                sprintf('The Wishlist with token %s does not exist', $wishlistToken),
+            );
+        }
+
+        if (!$this->security->isGranted(WishlistVoter::DELETE, $wishlist)) {
+            throw new AccessDeniedException();
+        }
+
+        $command = new RemoveProductFromWishlist($productId);
+        $command->setWishlist($wishlist);
+        $this->messageBus->dispatch($command);
 
         return new JsonResponse([], Response::HTTP_NO_CONTENT);
     }

--- a/src/Controller/Action/ApiPlatform/RemoveProductVariantFromWishlistAction.php
+++ b/src/Controller/Action/ApiPlatform/RemoveProductVariantFromWishlistAction.php
@@ -14,15 +14,23 @@ declare(strict_types=1);
 namespace Sylius\WishlistPlugin\Controller\Action\ApiPlatform;
 
 use Sylius\WishlistPlugin\Command\Wishlist\RemoveProductVariantFromWishlist;
+use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
+use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
+use Sylius\WishlistPlugin\Voter\WishlistVoter;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final readonly class RemoveProductVariantFromWishlistAction
 {
-    public function __construct(private MessageBusInterface $messageBus)
-    {
+    public function __construct(
+        private MessageBusInterface $messageBus,
+        private WishlistRepositoryInterface $wishlistRepository,
+        private Security $security,
+    ) {
     }
 
     public function __invoke(Request $request): JsonResponse
@@ -30,8 +38,21 @@ final readonly class RemoveProductVariantFromWishlistAction
         $wishlistToken = (string) $request->attributes->get('token');
         $productVariantId = (int) $request->attributes->get('productVariantId');
 
-        $removeProductVariantFromWishlist = new RemoveProductVariantFromWishlist($productVariantId, $wishlistToken);
-        $this->messageBus->dispatch($removeProductVariantFromWishlist);
+        $wishlist = $this->wishlistRepository->findByToken($wishlistToken);
+
+        if (null === $wishlist) {
+            throw new WishlistNotFoundException(
+                sprintf('The Wishlist with token %s does not exist', $wishlistToken),
+            );
+        }
+
+        if (!$this->security->isGranted(WishlistVoter::DELETE, $wishlist)) {
+            throw new AccessDeniedException();
+        }
+
+        $command = new RemoveProductVariantFromWishlist($productVariantId);
+        $command->setWishlist($wishlist);
+        $this->messageBus->dispatch($command);
 
         return new JsonResponse([], Response::HTTP_NO_CONTENT);
     }

--- a/tests/Unit/CommandHandler/Wishlist/RemoveProductFromWishlistHandlerTest.php
+++ b/tests/Unit/CommandHandler/Wishlist/RemoveProductFromWishlistHandlerTest.php
@@ -13,55 +13,33 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\WishlistPlugin\Unit\CommandHandler\Wishlist;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Sylius\Resource\ResourceActions;
 use Sylius\WishlistPlugin\Command\Wishlist\RemoveProductFromWishlist;
 use Sylius\WishlistPlugin\CommandHandler\Wishlist\RemoveProductFromWishlistHandler;
 use Sylius\WishlistPlugin\Entity\WishlistInterface;
 use Sylius\WishlistPlugin\Entity\WishlistProductInterface;
 use Sylius\WishlistPlugin\Exception\ProductNotFoundException;
-use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
-use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 final class RemoveProductFromWishlistHandlerTest extends TestCase
 {
     private MockObject&ProductRepositoryInterface $productRepository;
 
-    private MockObject&WishlistRepositoryInterface $wishlistRepository;
-
-    private MockObject&RepositoryInterface $wishlistProductRepository;
-
     private MockObject&ObjectManager $wishlistManager;
-
-    private MockObject&AuthorizationCheckerInterface $authorizationChecker;
-
-    private MockObject&ProductInterface $product;
-
-    private RemoveProductFromWishlist $command;
 
     private RemoveProductFromWishlistHandler $handler;
 
     protected function setUp(): void
     {
         $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
-        $this->wishlistRepository = $this->createMock(WishlistRepositoryInterface::class);
-        $this->wishlistProductRepository = $this->createMock(RepositoryInterface::class);
         $this->wishlistManager = $this->createMock(ObjectManager::class);
-        $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $this->product = $this->createMock(ProductInterface::class);
-        $this->command = new RemoveProductFromWishlist(1, 'wishlist_token');
         $this->handler = new RemoveProductFromWishlistHandler(
             $this->productRepository,
-            $this->wishlistRepository,
-            $this->wishlistProductRepository,
             $this->wishlistManager,
-            $this->authorizationChecker,
         );
     }
 
@@ -72,38 +50,36 @@ final class RemoveProductFromWishlistHandlerTest extends TestCase
 
     public function testShouldRemoveProductFromWishlist(): void
     {
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('getId')->willReturn(1);
+
         $wishlist = $this->createMock(WishlistInterface::class);
         $wishlistProduct = $this->createMock(WishlistProductInterface::class);
+        $wishlistProduct->method('getProduct')->willReturn($product);
 
-        $this->productRepository->expects($this->once())->method('find')->with(1)->willReturn($this->product);
-        $this->wishlistRepository->expects($this->once())->method('findByToken')->with('wishlist_token')->willReturn($wishlist);
-        $this->wishlistProductRepository->expects($this->once())->method('findOneBy')->with(['product' => $this->product, 'wishlist' => $wishlist])->willReturn($wishlistProduct);
-        $this->authorizationChecker->expects($this->once())->method('isGranted')->with(ResourceActions::DELETE, $wishlist)->willReturn(true);
+        $wishlist->method('getWishlistProducts')->willReturn(new ArrayCollection([$wishlistProduct]));
+
+        $this->productRepository->expects($this->once())->method('find')->with(1)->willReturn($product);
         $wishlist->expects($this->once())->method('removeProduct')->with($wishlistProduct);
         $this->wishlistManager->expects($this->once())->method('flush');
 
-        $this->assertSame(
-            $wishlist,
-            ($this->handler)($this->command),
-        );
+        $command = new RemoveProductFromWishlist(1);
+        $command->setWishlist($wishlist);
+
+        $this->assertSame($wishlist, ($this->handler)($command));
     }
 
     public function testShouldThrowExceptionWhenProductNotFound(): void
     {
         $this->expectException(ProductNotFoundException::class);
 
+        $wishlist = $this->createMock(WishlistInterface::class);
+
         $this->productRepository->expects($this->once())->method('find')->with(1)->willReturn(null);
 
-        ($this->handler)($this->command);
-    }
+        $command = new RemoveProductFromWishlist(1);
+        $command->setWishlist($wishlist);
 
-    public function testShouldThrowExceptionWhenWishlistNotFound(): void
-    {
-        $this->expectException(WishlistNotFoundException::class);
-
-        $this->productRepository->expects($this->once())->method('find')->with(1)->willReturn($this->product);
-        $this->wishlistRepository->expects($this->once())->method('findByToken')->with('wishlist_token')->willReturn(null);
-
-        ($this->handler)($this->command);
+        ($this->handler)($command);
     }
 }

--- a/tests/Unit/CommandHandler/Wishlist/RemoveProductVariantFromWishlistHandlerTest.php
+++ b/tests/Unit/CommandHandler/Wishlist/RemoveProductVariantFromWishlistHandlerTest.php
@@ -13,55 +13,33 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\WishlistPlugin\Unit\CommandHandler\Wishlist;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Sylius\Resource\ResourceActions;
 use Sylius\WishlistPlugin\Command\Wishlist\RemoveProductVariantFromWishlist;
 use Sylius\WishlistPlugin\CommandHandler\Wishlist\RemoveProductVariantFromWishlistHandler;
 use Sylius\WishlistPlugin\Entity\WishlistInterface;
 use Sylius\WishlistPlugin\Entity\WishlistProductInterface;
 use Sylius\WishlistPlugin\Exception\ProductVariantNotFoundException;
-use Sylius\WishlistPlugin\Exception\WishlistNotFoundException;
-use Sylius\WishlistPlugin\Repository\WishlistRepositoryInterface;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 final class RemoveProductVariantFromWishlistHandlerTest extends TestCase
 {
-    private MockObject&WishlistRepositoryInterface $wishlistRepository;
-
     private MockObject&ProductVariantRepositoryInterface $productVariantRepository;
 
-    private MockObject&RepositoryInterface $wishlistProductRepository;
-
     private MockObject&ObjectManager $wishlistManager;
-
-    private MockObject&AuthorizationCheckerInterface $authorizationChecker;
-
-    private MockObject&ProductVariantInterface $productVariant;
-
-    private RemoveProductVariantFromWishlist $command;
 
     private RemoveProductVariantFromWishlistHandler $handler;
 
     protected function setUp(): void
     {
-        $this->wishlistRepository = $this->createMock(WishlistRepositoryInterface::class);
         $this->productVariantRepository = $this->createMock(ProductVariantRepositoryInterface::class);
-        $this->wishlistProductRepository = $this->createMock(RepositoryInterface::class);
         $this->wishlistManager = $this->createMock(ObjectManager::class);
-        $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $this->productVariant = $this->createMock(ProductVariantInterface::class);
-        $this->command = new RemoveProductVariantFromWishlist(1, 'wishlist_token');
         $this->handler = new RemoveProductVariantFromWishlistHandler(
-            $this->wishlistRepository,
             $this->productVariantRepository,
-            $this->wishlistProductRepository,
             $this->wishlistManager,
-            $this->authorizationChecker,
         );
     }
 
@@ -72,38 +50,36 @@ final class RemoveProductVariantFromWishlistHandlerTest extends TestCase
 
     public function testShouldRemoveProductVariantFromWishlist(): void
     {
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $variant->method('getId')->willReturn(1);
+
         $wishlist = $this->createMock(WishlistInterface::class);
         $wishlistProduct = $this->createMock(WishlistProductInterface::class);
+        $wishlistProduct->method('getVariant')->willReturn($variant);
 
-        $this->productVariantRepository->expects($this->once())->method('find')->with(1)->willReturn($this->productVariant);
-        $this->wishlistRepository->expects($this->once())->method('findByToken')->with('wishlist_token')->willReturn($wishlist);
-        $this->wishlistProductRepository->expects($this->once())->method('findOneBy')->with(['variant' => $this->productVariant, 'wishlist' => $wishlist])->willReturn($wishlistProduct);
-        $this->authorizationChecker->expects($this->once())->method('isGranted')->with(ResourceActions::DELETE, $wishlist)->willReturn(true);
+        $wishlist->method('getWishlistProducts')->willReturn(new ArrayCollection([$wishlistProduct]));
+
+        $this->productVariantRepository->expects($this->once())->method('find')->with(1)->willReturn($variant);
         $wishlist->expects($this->once())->method('removeProduct')->with($wishlistProduct);
         $this->wishlistManager->expects($this->once())->method('flush');
 
-        $this->assertSame(
-            $wishlist,
-            ($this->handler)($this->command),
-        );
+        $command = new RemoveProductVariantFromWishlist(1);
+        $command->setWishlist($wishlist);
+
+        $this->assertSame($wishlist, ($this->handler)($command));
     }
 
     public function testShouldThrowExceptionWhenProductVariantNotFound(): void
     {
         $this->expectException(ProductVariantNotFoundException::class);
 
+        $wishlist = $this->createMock(WishlistInterface::class);
+
         $this->productVariantRepository->expects($this->once())->method('find')->with(1)->willReturn(null);
 
-        ($this->handler)($this->command);
-    }
+        $command = new RemoveProductVariantFromWishlist(1);
+        $command->setWishlist($wishlist);
 
-    public function testShouldThrowExceptionWhenWishlistNotFound(): void
-    {
-        $this->expectException(WishlistNotFoundException::class);
-
-        $this->productVariantRepository->expects($this->once())->method('find')->with(1)->willReturn($this->productVariant);
-        $this->wishlistRepository->expects($this->once())->method('findByToken')->with('wishlist_token')->willReturn(null);
-
-        ($this->handler)($this->command);
+        ($this->handler)($command);
     }
 }


### PR DESCRIPTION
Summary                                                                                                                                                                                     
                                                                                                                                                                                              
  - Align RemoveProductFromWishlist and RemoveProductVariantFromWishlist commands with the existing AddProductToWishlist pattern — accept a WishlistInterface via setWishlist() instead of a  
  wishlist token string                                                                                                                                                                       
  - The wishlist token is not unique per wishlist — all wishlists belonging to an anonymous user share the same cookie token, so findByToken() would silently return the first match, making  
  it impossible to target a specific wishlist in multi-wishlist scenarios                                                                                                                     
  - Handlers are now pure business logic — no authorization checks or repository lookups                                                                                                      
  - Authorization (WishlistVoter::DELETE) moved to API controllers, which is the appropriate layer for security checks 