### PR TITLE
FIX: [Shop] #37 use translation for default wishlist name

### DIFF
--- a/features/showing_chosen_wishlist.feature
+++ b/features/showing_chosen_wishlist.feature
@@ -20,3 +20,9 @@ Feature: Showing chosen wishlist
     When I open "Wishlist2"
     Then I should see "Wishlist2"
     And I should have "Jack Daniels Gentleman" in selected wishlists "Wishlist2"
+
+  @ui
+  Scenario: Showing a wishlist without a name displays the default translatable title
+    And the store has a wishlist without a name
+    When I visit this wishlist
+    Then the wishlist title should be "Wishlist"

--- a/src/CommandHandler/Wishlist/CreateWishlistHandler.php
+++ b/src/CommandHandler/Wishlist/CreateWishlistHandler.php
@@ -50,7 +50,6 @@ final readonly class CreateWishlistHandler
 
         /** @var WishlistInterface $wishlist */
         $wishlist = $this->wishlistFactory->createNew();
-        $wishlist->setName('Wishlist');
 
         if ($user instanceof ShopUserInterface) {
             $wishlist = $this->shopUserWishlistResolver->resolve($user);

--- a/src/Factory/WishlistFactory.php
+++ b/src/Factory/WishlistFactory.php
@@ -30,8 +30,6 @@ final readonly class WishlistFactory implements WishlistFactoryInterface
         /** @var WishlistInterface $wishlist */
         $wishlist = $this->wishlistFactory->createNew();
 
-        $wishlist->setName('Wishlist');
-
         return $wishlist;
     }
 

--- a/templates/wishlist_details/index.html.twig
+++ b/templates/wishlist_details/index.html.twig
@@ -7,7 +7,11 @@
 {% block content %}
     <div class="container mt-4 mb-5">
         <h1 class="bb-wishlist-header">
-            {{ wishlist.name }}
+            {% if wishlist.name is not empty %}
+                {{ wishlist.name }}
+            {% else %}
+                {{ 'sylius_wishlist_plugin.ui.wishlist'|trans }}
+            {% endif %}
         </h1>
         {% if sylius.channel is not null %}
             {% set wishlists = findAllByAnonymousAndChannel(sylius.channel) %}

--- a/tests/Behat/Context/Ui/WishlistContext.php
+++ b/tests/Behat/Context/Ui/WishlistContext.php
@@ -157,6 +157,45 @@ final class WishlistContext extends RawMinkContext implements Context
     }
 
     /**
+     * @Given the store has a wishlist without a name
+     */
+    public function theStoreHasAWishlistWithoutAName(): void
+    {
+        $cookie = $this->getSession()->getCookie($this->wishlistCookieToken);
+        $wishlist = new Wishlist();
+        $channel = $this->channelRepository->findOneByCode('WEB-US');
+
+        $wishlist->setChannel($channel);
+
+        if (null !== $cookie) {
+            $wishlist->setToken($cookie);
+        }
+
+        $this->wishlistRepository->add($wishlist);
+        $this->sharedStorage->set('wishlist', $wishlist);
+        $this->getSession()->setCookie($this->wishlistCookieToken, $wishlist->getToken());
+        $this->cookieSetter->setCookie($this->wishlistCookieToken, $wishlist->getToken());
+    }
+
+    /**
+     * @When I visit this wishlist
+     */
+    public function iVisitThisWishlist(): void
+    {
+        /** @var WishlistInterface $wishlist */
+        $wishlist = $this->sharedStorage->get('wishlist');
+        $this->visitPath('/wishlists/' . $wishlist->getId());
+    }
+
+    /**
+     * @Then the wishlist title should be :title
+     */
+    public function theWishlistTitleShouldBe(string $title): void
+    {
+        Assert::eq($title, $this->chosenShowPage->getWishlistTitle());
+    }
+
+    /**
      * @Given the store has a wishlist named :name
      */
     public function theStoreHasAWishlist(string $name): void

--- a/tests/Behat/Page/Shop/Wishlist/ChosenShowPage.php
+++ b/tests/Behat/Page/Shop/Wishlist/ChosenShowPage.php
@@ -21,4 +21,16 @@ final class ChosenShowPage extends SymfonyPage implements ChosenShowPageInterfac
     {
         return 'sylius_wishlist_plugin_shop_locale_wishlist_show_chosen_wishlist';
     }
+
+    public function getWishlistTitle(): string
+    {
+        return trim($this->getElement('wishlist_title')->getText());
+    }
+
+    protected function getDefinedElements(): array
+    {
+        return array_merge(parent::getDefinedElements(), [
+            'wishlist_title' => 'h1.bb-wishlist-header',
+        ]);
+    }
 }

--- a/tests/Behat/Page/Shop/Wishlist/ChosenShowPageInterface.php
+++ b/tests/Behat/Page/Shop/Wishlist/ChosenShowPageInterface.php
@@ -17,4 +17,5 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 
 interface ChosenShowPageInterface extends SymfonyPageInterface
 {
+    public function getWishlistTitle(): string;
 }

--- a/tests/Unit/CommandHandler/Wishlist/CreateWishlistHandlerTest.php
+++ b/tests/Unit/CommandHandler/Wishlist/CreateWishlistHandlerTest.php
@@ -104,7 +104,6 @@ final class CreateWishlistHandlerTest extends TestCase
         $this->tokenUserResolver->expects($this->once())->method('resolve')->with($token)->willReturn($this->user);
         $this->wishlistFactory->expects($this->once())->method('createNew')->willReturn($this->wishlist);
         $this->shopUserWishlistResolver->expects($this->once())->method('resolve')->with($this->user)->willReturn($this->wishlist);
-        $this->wishlist->expects($this->once())->method('setName')->with('Wishlist');
         $this->wishlist->expects($this->once())->method('setToken')->with('test_token_value');
         $this->requestStack->expects($this->once())->method('getMainRequest')->willReturn($this->request);
         $this->channelRepository->expects($this->once())->method('findOneByCode')->with('test_channel_code')->willReturn($this->channel);
@@ -123,7 +122,6 @@ final class CreateWishlistHandlerTest extends TestCase
         $this->tokenUserResolver->expects($this->once())->method('resolve')->with(null)->willReturn(null);
         $this->wishlistFactory->expects($this->once())->method('createNew')->willReturn($this->wishlist);
         $this->shopUserWishlistResolver->expects($this->never())->method('resolve')->with($this->user);
-        $this->wishlist->expects($this->once())->method('setName')->with('Wishlist');
         $this->wishlist->expects($this->once())->method('setToken')->with('test_token_value');
         $this->requestStack->expects($this->once())->method('getMainRequest')->willReturn($this->request);
         $this->channelRepository->expects($this->never())->method('findOneByCode')->with('test');

--- a/tests/Unit/Factory/WishlistFactoryTest.php
+++ b/tests/Unit/Factory/WishlistFactoryTest.php
@@ -61,7 +61,6 @@ final class WishlistFactoryTest extends TestCase
         $shopUser = $this->createMock(ShopUserInterface::class);
 
         $this->innerFactory->expects($this->once())->method('createNew')->willReturn($this->wishlist);
-        $this->wishlist->expects($this->once())->method('setName')->with();
         $this->wishlist->expects($this->once())->method('setShopUser')->with($shopUser);
 
         $this->assertSame(


### PR DESCRIPTION
**Description**
When you have no wishlists and adding a product to the wishlist, a default wishlist will be created. And so far the name was always set to `Wishlist` hardcoded.

As proposed in #37 i changed it so it checks if there is a translation key `sylius_wishlist_plugin.ui.wishlist`. If so, it uses the translation under this key. And if not, `Wishlist` will be used as a default.